### PR TITLE
1 WeekFix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,6 @@ out/
 
 ### VS Code ###
 .vscode/
+
+### Custon ###
+application-secret.yml

--- a/records/1Week_WooHyeJi.md
+++ b/records/1Week_WooHyeJi.md
@@ -8,34 +8,47 @@
 - [x] [필수] 호감상대 삭제
     - [x] 삭제 버튼을 눌렀을 시 해당 항목은 삭제되어야 한다.
     - [x] 삭제를 처리하기 전 해당 항목에 대한 소유권이 본인(로그인한 사람)에게 있는지 체크해야한다.
-    - [x] 삭제 후 다시 호감목록 페이지로 돌아와야 한다. (rq.redirectWithMsg 사용)
-- [ ] [선택] 구글 로그인
-    - [ ] 구글 로그인으로 가입 및 로그인 처리가 가능하여야 한다. (스프링 OAuth2 클라이언트)
-    - [ ] 구글 로그인으로 가입한 회원의 providerTypeCode : GOOGLE
+    - [x] 삭제 후 다시 호감목록 페이지로 돌아와야 한다. (`rq.redirectWithMsg` 사용)
+- [x] [선택] 구글 로그인
+    - [x] 구글 로그인으로 가입 및 로그인 처리가 가능하여야 한다. (스프링 OAuth2 클라이언트)
+    - [x] 구글 로그인으로 가입한 회원의 providerTypeCode : GOOGLE
 
-### N주차 미션 요약
+### 1주차 미션 요약
 
 ---
 
 **[접근 방법]**
 1. **호감상대 삭제**
     - 호감목록에서 삭제하려고 하는 항목은 LikeablePersonRepository 의 id 를 기준으로 찾야야한다.
-        - LikeablePersonService 에서 findById 함수를 통해 해당 repository 에서 id를 가져온다.
-    - LikeablePersonService 에서 delete 함수를 만든다.
+        - LikeablePersonService 에서 `findById` 함수를 통해 해당 repository 에서 id를 가져온다.
+    - LikeablePersonService 에서 `delete` 함수를 만든다.
         - 존재하지 않는 항목을 삭제하려고 했을 때 실패
         - 로그인한 사람에게 삭제 권한이 없는 경우 실패
-    - LikeablePersonController 에서 해당 항목의 삭제버튼을 눌러 "/delete/{id}" 경로로 들어갔을 때 delete 구현
-        - "/delete/{id}" 에서 id는 LikeablePersonRepository 에서 가져온 id
-        - 호감상대 삭제가 실패한다면 rq.historyBack 을 통해 돌아간다.
-    - 호감상대를 삭제한 후 rq.redirectWithMsg 를 통해 "/likeablePerson/list"로 돌아간다.
+    - LikeablePersonController 에서 해당 항목의 삭제버튼을 눌러 `"/delete/{id}"` 경로로 들어갔을 때 delete 구현
+        - `"/delete/{id}"` 에서 id는 LikeablePersonRepository 에서 가져온 id
+        - 호감상대 삭제가 실패한다면 `rq.historyBack` 을 통해 돌아간다.
+    - 호감상대를 삭제한 후 `rq.redirectWithMsg` 를 통해 "/likeablePerson/list"로 돌아간다.
 2. **구글 로그인**
     - 아직 구현하지 못함
 
 **[특이사항]**
 - 호감상대 삭제에 대한 테스트케이스는 실행되지만 GramgramApplication을 실행했을 때에는 list에서 삭제가 되지 않는 오류가 발생.
     
-    -> LikeablePersonService.java 의 delete에 @Transactional 추가하니 삭제 가능 
+    -> LikeablePersonService.java 의 delete에 `@Transactional` 추가하니 삭제 가능 
 
 
-**참고: [Refactoring]**
-
+**[Refactoring]**
+1. **호감상대 삭제**
+    - 호감취소 관련 변수명 정리
+      - `RsData` -> `deleteRsData`
+    - 호감상대 등록시 예외처리 케이스 메서드 새로 만들어서 분리
+    - `@OneToMany` 사용하여 내가(or나를) 좋아하는 사람의 명단 양방향 관계 설정
+      - 부작용이 생겨 오류 수정 (호감표시 페이지 작동 X)
+    - 테스트케이스(t6, t7, t8) 수정
+2. **카카오/구글 로그인**
+    - 기존 카카오 clientId가 git에 노출됨
+        -> application-secret.yml 새로 생성하여 정보 이동
+    - 구글 프로젝트 생성 후 application.yml에 추가
+        -> 카카오 로그인과 마찬가지로 clientId와 비밀번호는 application-secret.yml에서 관리
+    - 협업 시 application-secret.yml은 git에 노출되지 않음
+        -> 폼 제공을 위해 applicaion-secret.yml.default 문서 추가

--- a/src/main/java/com/ll/gramgram/base/initData/NotProd.java
+++ b/src/main/java/com/ll/gramgram/base/initData/NotProd.java
@@ -25,7 +25,7 @@ public class NotProd {
             Member memberUser3 = memberService.join("user3", "1234").getData();
             Member memberUser4 = memberService.join("user4", "1234").getData();
 
-            Member memberUser5ByKakao = memberService.whenSocialLogin("KAKAO", "KAKAO__2733172749").getData();
+            Member memberUser5ByKakao = memberService.whenSocialLogin("KAKAO", "KAKAO__2740964333").getData();
 
             instaMemberService.connect(memberUser2, "insta_user2", "M");
             instaMemberService.connect(memberUser3, "insta_user3", "W");

--- a/src/main/java/com/ll/gramgram/base/initData/NotProd.java
+++ b/src/main/java/com/ll/gramgram/base/initData/NotProd.java
@@ -26,6 +26,7 @@ public class NotProd {
             Member memberUser4 = memberService.join("user4", "1234").getData();
 
             Member memberUser5ByKakao = memberService.whenSocialLogin("KAKAO", "KAKAO__2740964333").getData();
+            Member memberUser6ByGoogle = memberService.whenSocialLogin("GOOGLE", "GOOGLE__110413650078988288945").getData();
 
             instaMemberService.connect(memberUser2, "insta_user2", "M");
             instaMemberService.connect(memberUser3, "insta_user3", "W");

--- a/src/main/java/com/ll/gramgram/base/rq/Rq.java
+++ b/src/main/java/com/ll/gramgram/base/rq/Rq.java
@@ -69,6 +69,8 @@ public class Rq {
         String key = "historyBackErrorMsg___" + referer;
         req.setAttribute("localStorageKeyAboutHistoryBackErrorMsg", key);
         req.setAttribute("historyBackErrorMsg", msg);
+        // 200 이 아니라 400 으로 응답코드가 지정되도록
+        resp.setStatus(HttpServletResponse.SC_BAD_REQUEST);
         return "common/js";
     }
 

--- a/src/main/java/com/ll/gramgram/boundedContext/home/controller/HomeController.java
+++ b/src/main/java/com/ll/gramgram/boundedContext/home/controller/HomeController.java
@@ -1,5 +1,6 @@
 package com.ll.gramgram.boundedContext.home.controller;
 
+import com.ll.gramgram.base.rq.Rq;
 import jakarta.servlet.http.HttpSession;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Controller;
@@ -11,6 +12,8 @@ import java.util.Enumeration;
 @Controller
 @RequiredArgsConstructor
 public class HomeController {
+    private final Rq rq;
+
     @GetMapping("/")
     public String showMain() {
         return "usr/home/main";
@@ -29,5 +32,10 @@ public class HomeController {
         }
 
         return sb.toString().replaceAll("\n", "<br>");
+    }
+
+    @GetMapping("/historyBackTest")
+    public String showHistoryBackTest(HttpSession session) {
+        return rq.historyBack("여기는 당신같은 사람이 오면 안되요.");
     }
 }

--- a/src/main/java/com/ll/gramgram/boundedContext/instaMember/entity/InstaMember.java
+++ b/src/main/java/com/ll/gramgram/boundedContext/instaMember/entity/InstaMember.java
@@ -40,4 +40,18 @@ public class InstaMember {
     @LazyCollection(LazyCollectionOption.EXTRA)
     @Builder.Default // @Builder가 있으면 ` = new ArrayList<>();` 가 작동하지 않는다. 그래서 이걸 붙여야 한다.
     private List<LikeablePerson> fromLikeablePeople = new ArrayList<>();
+
+    @OneToMany(mappedBy = "toInstaMember", cascade = {CascadeType.ALL})
+    @OrderBy("id desc") // 정렬
+    @LazyCollection(LazyCollectionOption.EXTRA)
+    @Builder.Default
+    private List<LikeablePerson> toLikeablePeople = new ArrayList<>();
+
+    public void addFromLikeablePerson(LikeablePerson likeablePerson) {
+        fromLikeablePeople.add(0, likeablePerson);
+    }
+
+    public void addToLikeablePerson(LikeablePerson likeablePerson) {
+        toLikeablePeople.add(0, likeablePerson);
+    }
 }

--- a/src/main/java/com/ll/gramgram/boundedContext/instaMember/entity/InstaMember.java
+++ b/src/main/java/com/ll/gramgram/boundedContext/instaMember/entity/InstaMember.java
@@ -1,12 +1,17 @@
 package com.ll.gramgram.boundedContext.instaMember.entity;
 
+import com.ll.gramgram.boundedContext.likeablePerson.entity.LikeablePerson;
 import jakarta.persistence.*;
 import lombok.*;
+import org.hibernate.annotations.LazyCollection;
+import org.hibernate.annotations.LazyCollectionOption;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
 
 import static jakarta.persistence.GenerationType.IDENTITY;
 
@@ -29,4 +34,10 @@ public class InstaMember {
     private String username;
     @Setter
     private String gender;
+
+    @OneToMany(mappedBy = "fromInstaMember", cascade = {CascadeType.ALL})
+    @OrderBy("id desc") // 정렬
+    @LazyCollection(LazyCollectionOption.EXTRA)
+    @Builder.Default // @Builder가 있으면 ` = new ArrayList<>();` 가 작동하지 않는다. 그래서 이걸 붙여야 한다.
+    private List<LikeablePerson> fromLikeablePeople = new ArrayList<>();
 }

--- a/src/main/java/com/ll/gramgram/boundedContext/likeablePerson/controller/LikeablePersonController.java
+++ b/src/main/java/com/ll/gramgram/boundedContext/likeablePerson/controller/LikeablePersonController.java
@@ -70,15 +70,8 @@ public class LikeablePersonController {
     @PreAuthorize("isAuthenticated()")
     @GetMapping("/delete/{id}")
     public String delete(@PathVariable("id") Long id) {
-        LikeablePerson likeablePerson = likeablePersonService.findById(id).orElse(null);
 
-        if (likeablePerson == null) return rq.historyBack("이미 취소된 호감입니다.");
-
-        if (!Objects.equals(rq.getMember().getInstaMember().getId(), likeablePerson.getFromInstaMember().getId())) {
-            return rq.historyBack("권한이 없습니다.");
-        };
-
-        RsData deleteRs = likeablePersonService.delete(likeablePerson);
+        RsData deleteRs = likeablePersonService.delete(rq.getMember(), id);
 
         if (deleteRs.isFail()) return rq.historyBack(deleteRs);
 

--- a/src/main/java/com/ll/gramgram/boundedContext/likeablePerson/controller/LikeablePersonController.java
+++ b/src/main/java/com/ll/gramgram/boundedContext/likeablePerson/controller/LikeablePersonController.java
@@ -12,10 +12,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.*;
 
 import java.security.Principal;
 import java.util.List;
@@ -68,7 +65,7 @@ public class LikeablePersonController {
     }
 
     @PreAuthorize("isAuthenticated()")
-    @PostMapping("/delete/{id}")
+    @DeleteMapping("/{id}")
     public String delete(@PathVariable("id") Long id) {
         LikeablePerson likeablePerson = likeablePersonService.findById(id).orElse(null);
 

--- a/src/main/java/com/ll/gramgram/boundedContext/likeablePerson/controller/LikeablePersonController.java
+++ b/src/main/java/com/ll/gramgram/boundedContext/likeablePerson/controller/LikeablePersonController.java
@@ -73,11 +73,11 @@ public class LikeablePersonController {
 
         if (canActorDeleteRsData.isFail()) return rq.historyBack(canActorDeleteRsData);
 
-        RsData deleteRs = likeablePersonService.delete(likeablePerson);
+        RsData deleteRsData = likeablePersonService.delete(likeablePerson);
 
-        if (deleteRs.isFail()) return rq.historyBack(deleteRs);
+        if (deleteRsData.isFail()) return rq.historyBack(deleteRsData);
 
         // 호감상대 삭제 후 "/likeablePerson/list" 로 돌아가기
-        return rq.redirectWithMsg("/likeablePerson/list", deleteRs);
+        return rq.redirectWithMsg("/likeablePerson/list", deleteRsData);
     }
 }

--- a/src/main/java/com/ll/gramgram/boundedContext/likeablePerson/controller/LikeablePersonController.java
+++ b/src/main/java/com/ll/gramgram/boundedContext/likeablePerson/controller/LikeablePersonController.java
@@ -68,7 +68,7 @@ public class LikeablePersonController {
     }
 
     @PreAuthorize("isAuthenticated()")
-    @GetMapping("/delete/{id}")
+    @PostMapping("/delete/{id}")
     public String delete(@PathVariable("id") Long id) {
         LikeablePerson likeablePerson = likeablePersonService.findById(id).orElse(null);
 

--- a/src/main/java/com/ll/gramgram/boundedContext/likeablePerson/controller/LikeablePersonController.java
+++ b/src/main/java/com/ll/gramgram/boundedContext/likeablePerson/controller/LikeablePersonController.java
@@ -70,11 +70,15 @@ public class LikeablePersonController {
     @PreAuthorize("isAuthenticated()")
     @GetMapping("/delete/{id}")
     public String delete(@PathVariable("id") Long id) {
+        LikeablePerson likeablePerson = likeablePersonService.findById(id).orElse(null);
 
-        RsData deleteRs = likeablePersonService.delete(rq.getMember(), id);
+        RsData canActorDeleteRsData = likeablePersonService.canActorDelete(rq.getMember(), likeablePerson);
+
+        if (canActorDeleteRsData.isFail()) return rq.historyBack(canActorDeleteRsData);
+
+        RsData deleteRs = likeablePersonService.delete(likeablePerson);
 
         if (deleteRs.isFail()) return rq.historyBack(deleteRs);
-
 
         // 호감상대 삭제 후 "/likeablePerson/list" 로 돌아가기
         return rq.redirectWithMsg("/likeablePerson/list", deleteRs);

--- a/src/main/java/com/ll/gramgram/boundedContext/likeablePerson/entity/LikeablePerson.java
+++ b/src/main/java/com/ll/gramgram/boundedContext/likeablePerson/entity/LikeablePerson.java
@@ -28,9 +28,11 @@ public class LikeablePerson {
     private LocalDateTime modifyDate;
 
     @ManyToOne
+    @ToString.Exclude
     private InstaMember fromInstaMember; // 호감을 표시한 사람(인스타 멤버)
     private String fromInstaMemberUsername; // 혹시 몰라서 기록
     @ManyToOne
+    @ToString.Exclude
     private InstaMember toInstaMember; // 호감을 받은 사람(인스타 멤버)
     private String toInstaMemberUsername; // 혹시 몰라서 기록
     private int attractiveTypeCode; // 매력포인트(1=외모, 2=성격, 3=능력)

--- a/src/main/java/com/ll/gramgram/boundedContext/likeablePerson/service/LikeablePersonService.java
+++ b/src/main/java/com/ll/gramgram/boundedContext/likeablePerson/service/LikeablePersonService.java
@@ -33,11 +33,12 @@ public class LikeablePersonService {
             return RsData.of("F-1", "본인을 호감상대로 등록할 수 없습니다.");
         }
 
+        InstaMember fromInstaMember = member.getInstaMember();
         InstaMember toInstaMember = instaMemberService.findByUsernameOrCreate(username).getData();
 
         LikeablePerson likeablePerson = LikeablePerson
                 .builder()
-                .fromInstaMember(member.getInstaMember()) // 호감을 표시하는 사람의 인스타 멤버
+                .fromInstaMember(fromInstaMember) // 호감을 표시하는 사람의 인스타 멤버
                 .fromInstaMemberUsername(member.getInstaMember().getUsername()) // 중요하지 않음
                 .toInstaMember(toInstaMember) // 호감을 받는 사람의 인스타 멤버
                 .toInstaMemberUsername(toInstaMember.getUsername()) // 중요하지 않음
@@ -45,6 +46,12 @@ public class LikeablePersonService {
                 .build();
 
         likeablePersonRepository.save(likeablePerson); // 저장
+
+        // 너가 좋아하는 호감표시 생겼어.
+        fromInstaMember.addFromLikeablePerson(likeablePerson);
+
+        // 너를 좋아하는 호감표시 생겼어.
+        toInstaMember.addToLikeablePerson(likeablePerson);
 
         return RsData.of("S-1", "입력하신 인스타유저(%s)를 호감상대로 등록되었습니다.".formatted(username), likeablePerson);
     }

--- a/src/main/java/com/ll/gramgram/boundedContext/likeablePerson/service/LikeablePersonService.java
+++ b/src/main/java/com/ll/gramgram/boundedContext/likeablePerson/service/LikeablePersonService.java
@@ -12,7 +12,6 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
-import java.util.Objects;
 import java.util.Optional;
 
 @Service
@@ -67,16 +66,21 @@ public class LikeablePersonService {
 
     @Transactional
     public RsData delete(LikeablePerson likeablePerson) {
-        String toInstaMemberUsername = likeablePerson.getToInstaMember().getUsername();
         likeablePersonRepository.delete(likeablePerson);
 
-        return RsData.of("S-1", "%s님에 대한 호감을 취소하였습니다.".formatted(toInstaMemberUsername));
+        String likeCanceledUsername = likeablePerson.getToInstaMember().getUsername();
+        return RsData.of("S-1", "%s님에 대한 호감을 취소하였습니다.".formatted(likeCanceledUsername));
     }
 
     public RsData canActorDelete(Member actor, LikeablePerson likeablePerson) {
         if (likeablePerson == null) return RsData.of("F-1", "이미 삭제되었습니다.");
 
-        if (!Objects.equals(actor.getInstaMember().getId(), likeablePerson.getFromInstaMember().getId()))
+        // 수행자의 인스타계정 번호
+        long actorInstaMemberId = actor.getInstaMember().getId();
+        // 삭제 대상의 작성자(호감표시한 사람)의 인스타계정 번호
+        long fromInstaMemberId = likeablePerson.getFromInstaMember().getId();
+
+        if (actorInstaMemberId != fromInstaMemberId)
             return RsData.of("F-2", "권한이 없습니다.");
 
         return RsData.of("S-1", "삭제 가능합니다.");

--- a/src/main/java/com/ll/gramgram/boundedContext/likeablePerson/service/LikeablePersonService.java
+++ b/src/main/java/com/ll/gramgram/boundedContext/likeablePerson/service/LikeablePersonService.java
@@ -12,6 +12,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
+import java.util.Objects;
 import java.util.Optional;
 
 @Service
@@ -58,7 +59,14 @@ public class LikeablePersonService {
     }
 
     @Transactional
-    public RsData delete(LikeablePerson likeablePerson) {
+    public RsData delete(Member actor, Long id) {
+        LikeablePerson likeablePerson = findById(id).orElse(null);
+
+        if (likeablePerson == null) return RsData.of("S-1", "이미 취소된 호감입니다.");
+
+        if (!Objects.equals(actor.getInstaMember().getId(), likeablePerson.getFromInstaMember().getId()))
+            return RsData.of("S-2", "권한이 없습니다.");
+
         String toInstaMemberUsername = likeablePerson.getToInstaMember().getUsername();
         likeablePersonRepository.delete(likeablePerson);
 

--- a/src/main/java/com/ll/gramgram/boundedContext/likeablePerson/service/LikeablePersonService.java
+++ b/src/main/java/com/ll/gramgram/boundedContext/likeablePerson/service/LikeablePersonService.java
@@ -59,17 +59,19 @@ public class LikeablePersonService {
     }
 
     @Transactional
-    public RsData delete(Member actor, Long id) {
-        LikeablePerson likeablePerson = findById(id).orElse(null);
-
-        if (likeablePerson == null) return RsData.of("S-1", "이미 취소된 호감입니다.");
-
-        if (!Objects.equals(actor.getInstaMember().getId(), likeablePerson.getFromInstaMember().getId()))
-            return RsData.of("S-2", "권한이 없습니다.");
-
+    public RsData delete(LikeablePerson likeablePerson) {
         String toInstaMemberUsername = likeablePerson.getToInstaMember().getUsername();
         likeablePersonRepository.delete(likeablePerson);
 
         return RsData.of("S-1", "%s님에 대한 호감을 취소하였습니다.".formatted(toInstaMemberUsername));
+    }
+
+    public RsData canActorDelete(Member actor, LikeablePerson likeablePerson) {
+        if (likeablePerson == null) return RsData.of("F-1", "이미 삭제되었습니다.");
+
+        if (!Objects.equals(actor.getInstaMember().getId(), likeablePerson.getFromInstaMember().getId()))
+            return RsData.of("F-2", "권한이 없습니다.");
+
+        return RsData.of("S-1", "삭제 가능합니다.");
     }
 }

--- a/src/main/java/com/ll/gramgram/boundedContext/likeablePerson/service/LikeablePersonService.java
+++ b/src/main/java/com/ll/gramgram/boundedContext/likeablePerson/service/LikeablePersonService.java
@@ -58,24 +58,10 @@ public class LikeablePersonService {
     }
 
     @Transactional
-    public RsData<LikeablePerson> delete(Long id, String username) {
-        Optional<LikeablePerson> likeablePerson = likeablePersonRepository.findById(id);
+    public RsData delete(LikeablePerson likeablePerson) {
+        String toInstaMemberUsername = likeablePerson.getToInstaMember().getUsername();
+        likeablePersonRepository.delete(likeablePerson);
 
-        if (!likeablePerson.isPresent()) {
-            return RsData.of("F-1", "존재하지 않는 항목입니다.");
-        }
-
-        // likeablePerson 의 fromInstaMember 가져오기
-        InstaMember instaMember = likeablePerson.get().getFromInstaMember();
-        // fromInstaMember 를 memberRepository 에서 찾아오기
-        Member member = memberRepository.findByInstaMember(instaMember);
-
-        // member의 username과 delete에서 입력된 username이 일치하는지 확인
-        if (!member.getUsername().equals(username)) {
-            return RsData.of("F-2", "삭제 권한이 없습니다.");
-        }
-
-        likeablePersonRepository.delete(likeablePerson.get());
-        return RsData.of("S-1", "호감 상대가 삭제되었습니다.");
+        return RsData.of("S-1", "%s님에 대한 호감을 취소하였습니다.".formatted(toInstaMemberUsername));
     }
 }

--- a/src/main/resources/application-secret.yml
+++ b/src/main/resources/application-secret.yml
@@ -1,0 +1,7 @@
+spring:
+  security:
+    oauth2:
+      client:
+        registration:
+          kakao:
+            clientId: fbffa4e961a667f39079c6d200d601a9

--- a/src/main/resources/application-secret.yml
+++ b/src/main/resources/application-secret.yml
@@ -5,3 +5,6 @@ spring:
         registration:
           kakao:
             clientId: fbffa4e961a667f39079c6d200d601a9
+          google:
+            clientId: 91043027399-lc6s8pccjts8edjtmjberfrt2bhqpfgj.apps.googleusercontent.com
+            client-secret: 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

--- a/src/main/resources/application-secret.yml.default
+++ b/src/main/resources/application-secret.yml.default
@@ -5,3 +5,6 @@ spring:
         registration:
           kakao:
             clientId: '카카오 클라이언트 ID'
+          google:
+            clientId: '구글 클라이언트 ID'
+            client-secret: '구글 클라이언트 시크릿'

--- a/src/main/resources/application-secret.yml.default
+++ b/src/main/resources/application-secret.yml.default
@@ -1,0 +1,7 @@
+spring:
+  security:
+    oauth2:
+      client:
+        registration:
+          kakao:
+            clientId: '카카오 클라이언트 ID'

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -19,8 +19,12 @@ spring:
             scope:
             client-name: Kakao
             authorization-grant-type: authorization_code
-            redirect-uri: http://localhost:8080/login/oauth2/code/kakao
+            redirect-uri: '{baseUrl}/{action}/oauth2/code/{registrationId}'
             client-authentication-method: POST
+          google:
+            redirect-uri: '{baseUrl}/{action}/oauth2/code/{registrationId}'
+            client-name: Google
+            scope: profile
         provider:
           kakao:
             authorization-uri: https://kauth.kakao.com/oauth/authorize

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -16,7 +16,6 @@ spring:
       client:
         registration:
           kakao:
-            clientId: '카카오 클라이언트 ID'
             scope:
             client-name: Kakao
             authorization-grant-type: authorization_code

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,4 +1,8 @@
 spring:
+  mvc:
+    hiddenmethod:
+      filter:
+        enabled: true
   profiles:
     active: dev
   datasource:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -5,6 +5,7 @@ spring:
         enabled: true
   profiles:
     active: dev
+    include: secret
   datasource:
     driver-class-name: org.mariadb.jdbc.Driver
     url: jdbc:mariadb://127.0.0.1:3306/gram__dev?useUnicode=true&characterEncoding=utf8&autoReconnect=true&serverTimezone=Asia/Seoul
@@ -15,7 +16,7 @@ spring:
       client:
         registration:
           kakao:
-            clientId: 4b1c4748b0d5e4ffb1c70f2971d77440
+            clientId: '카카오 클라이언트 ID'
             scope:
             client-name: Kakao
             authorization-grant-type: authorization_code

--- a/src/main/resources/templates/usr/home/main.html
+++ b/src/main/resources/templates/usr/home/main.html
@@ -8,6 +8,8 @@
 
 <main layout:fragment="main">
     메인입니다.
+
+    <a class="btn btn-link" href="/historyBackTest">히스토리 백 테스트</a>
 </main>
 
 </body>

--- a/src/main/resources/templates/usr/layout/layout.html
+++ b/src/main/resources/templates/usr/layout/layout.html
@@ -39,7 +39,8 @@
     <a href="/likeablePerson/list" th:if="${@rq.login}" class="btn btn-link">호감목록</a>
     <a href="javascript:;" th:if="${@rq.login}" onclick="$(this).next().submit();" class="btn btn-link">로그아웃</a>
     <form th:if="${@rq.login}" hidden th:action="|/member/logout|" method="POST"></form>
-    <span th:if="${@rq.login}" th:text="|${@rq.member.username}님 환영합니다.(${#lists.size(@rq.member.instaMember.toLikeablePeople)}/${#lists.size(@rq.member.instaMember.fromLikeablePeople)})|"></span>
+    <span th:if="${@rq.login}" th:text="|${@rq.member.username}님 환영합니다.|"></span>
+    <span th:if="${@rq.login and @rq.member.hasConnectedInstaMember()}" th:text="|(${#lists.size(@rq.member.instaMember.toLikeablePeople)}/${#lists.size(@rq.member.instaMember.fromLikeablePeople)})|"></span>
 </header>
 
 <main layout:fragment="main"></main>

--- a/src/main/resources/templates/usr/layout/layout.html
+++ b/src/main/resources/templates/usr/layout/layout.html
@@ -65,6 +65,13 @@
         if (localStorage.getItem(localStorageKeyAboutHistoryBackErrorMsg)) {
             toastWarning(localStorage.getItem(localStorageKeyAboutHistoryBackErrorMsg));
             localStorage.removeItem(localStorageKeyAboutHistoryBackErrorMsg);
+        } else if ( !document.referrer ) {
+            const localStorageKeyAboutHistoryBackErrorMsg = "historyBackErrorMsg___null";
+
+            if (localStorage.getItem(localStorageKeyAboutHistoryBackErrorMsg)) {
+                toastWarning(localStorage.getItem(localStorageKeyAboutHistoryBackErrorMsg));
+                localStorage.removeItem(localStorageKeyAboutHistoryBackErrorMsg);
+            }
         }
     });
 </script>

--- a/src/main/resources/templates/usr/layout/layout.html
+++ b/src/main/resources/templates/usr/layout/layout.html
@@ -39,7 +39,7 @@
     <a href="/likeablePerson/list" th:if="${@rq.login}" class="btn btn-link">호감목록</a>
     <a href="javascript:;" th:if="${@rq.login}" onclick="$(this).next().submit();" class="btn btn-link">로그아웃</a>
     <form th:if="${@rq.login}" hidden th:action="|/member/logout|" method="POST"></form>
-    <span th:if="${@rq.login}" th:text="|${@rq.member.username}님 환영합니다.|"></span>
+    <span th:if="${@rq.login}" th:text="|${@rq.member.username}님 환영합니다.(${#lists.size(@rq.member.instaMember.fromLikeablePeople)})|"></span>
 </header>
 
 <main layout:fragment="main"></main>

--- a/src/main/resources/templates/usr/layout/layout.html
+++ b/src/main/resources/templates/usr/layout/layout.html
@@ -39,7 +39,7 @@
     <a href="/likeablePerson/list" th:if="${@rq.login}" class="btn btn-link">호감목록</a>
     <a href="javascript:;" th:if="${@rq.login}" onclick="$(this).next().submit();" class="btn btn-link">로그아웃</a>
     <form th:if="${@rq.login}" hidden th:action="|/member/logout|" method="POST"></form>
-    <span th:if="${@rq.login}" th:text="|${@rq.member.username}님 환영합니다.(${#lists.size(@rq.member.instaMember.fromLikeablePeople)})|"></span>
+    <span th:if="${@rq.login}" th:text="|${@rq.member.username}님 환영합니다.(${#lists.size(@rq.member.instaMember.toLikeablePeople)}/${#lists.size(@rq.member.instaMember.fromLikeablePeople)})|"></span>
 </header>
 
 <main layout:fragment="main"></main>

--- a/src/main/resources/templates/usr/likeablePerson/add.html
+++ b/src/main/resources/templates/usr/likeablePerson/add.html
@@ -17,7 +17,7 @@
 
     <th:block th:if="${@rq.member.hasConnectedInstaMember}">
         <script th:inline="javascript">
-            const myInstaMember = /*[[ ${@rq.member.instaMember} ]]*/ null;
+            const myInstaMemberUsername = /*[[ ${@rq.member.instaMember.username} ]]*/ null;
 
             function AddForm__submit(form) {
                 // username 이(가) 올바른지 체크
@@ -36,7 +36,7 @@
                     return;
                 }
 
-                if (form.username.value == myInstaMember.username) {
+                if (form.username.value == myInstaMemberUsername) {
                     toastWarning('본인을 호감상대로 등록할 수 없습니다.');
                     form.username.focus();
                     return;

--- a/src/main/resources/templates/usr/likeablePerson/list.html
+++ b/src/main/resources/templates/usr/likeablePerson/list.html
@@ -22,7 +22,9 @@
                 <span class="toInstaMember_attractiveTypeDisplayName"
                       th:text="${likeablePerson.attractiveTypeDisplayName}"></span>
                 <a href="javascript:;" onclick="if ( confirm('정말로 삭제하시겠습니까?') ) $(this).next().submit();">삭제</a>
-                <form hidden th:action="@{|delete/${likeablePerson.id}|}" method="POST"></form>
+                <form hidden th:action="@{|/likeablePerson/${likeablePerson.id}|}" method="POST">
+                    <input type="hidden" name="_method" value="delete">
+                </form>
             </li>
         </ul>
     </th:block>

--- a/src/main/resources/templates/usr/likeablePerson/list.html
+++ b/src/main/resources/templates/usr/likeablePerson/list.html
@@ -21,7 +21,8 @@
                 <span class="toInstaMember_username" th:text="${likeablePerson.toInstaMember.username}"></span>
                 <span class="toInstaMember_attractiveTypeDisplayName"
                       th:text="${likeablePerson.attractiveTypeDisplayName}"></span>
-                <a th:href="@{|delete/${likeablePerson.id}|}" onclick="return confirm('정말로 삭제하시겠습니까?');">삭제</a>
+                <a href="javascript:;" onclick="if ( confirm('정말로 삭제하시겠습니까?') ) $(this).next().submit();">삭제</a>
+                <form hidden th:action="@{|delete/${likeablePerson.id}|}" method="POST"></form>
             </li>
         </ul>
     </th:block>

--- a/src/main/resources/templates/usr/member/login.html
+++ b/src/main/resources/templates/usr/member/login.html
@@ -63,7 +63,7 @@
         </a>
 
         <a class="btn btn-link" href="/oauth2/authorization/google">
-            구글 로그인하기(아직 안됨)
+            구글 로그인하기
         </a>
 
         <a class="btn btn-link" href="/oauth2/authorization/naver">

--- a/src/test/java/com/ll/gramgram/boundedContext/likeablePerson/controller/LikeablePersonControllerTests.java
+++ b/src/test/java/com/ll/gramgram/boundedContext/likeablePerson/controller/LikeablePersonControllerTests.java
@@ -1,7 +1,6 @@
 package com.ll.gramgram.boundedContext.likeablePerson.controller;
 
 
-import com.ll.gramgram.boundedContext.likeablePerson.entity.LikeablePerson;
 import com.ll.gramgram.boundedContext.likeablePerson.service.LikeablePersonService;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -17,8 +16,7 @@ import org.springframework.transaction.annotation.Transactional;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.hamcrest.Matchers.containsString;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
@@ -163,7 +161,7 @@ public class LikeablePersonControllerTests {
         // WHEN
         ResultActions resultActions = mvc
                 .perform(
-                        post("/likeablePerson/delete/1")
+                        delete("/likeablePerson/1")
                                 .with(csrf())
                 )
                 .andDo(print());
@@ -173,7 +171,8 @@ public class LikeablePersonControllerTests {
                 .andExpect(handler().handlerType(LikeablePersonController.class))
                 .andExpect(handler().methodName("delete"))
                 .andExpect(status().is3xxRedirection())
-                .andExpect(redirectedUrlPattern("/likeablePerson/list**"));
+                .andExpect(redirectedUrlPattern("/likeablePerson/list**"))
+        ;
 
         assertThat(likeablePersonService.findById(1L).isPresent()).isEqualTo(false);
     }

--- a/src/test/java/com/ll/gramgram/boundedContext/likeablePerson/controller/LikeablePersonControllerTests.java
+++ b/src/test/java/com/ll/gramgram/boundedContext/likeablePerson/controller/LikeablePersonControllerTests.java
@@ -162,7 +162,10 @@ public class LikeablePersonControllerTests {
     void t006() throws Exception {
         // WHEN
         ResultActions resultActions = mvc
-                .perform(get("/likeablePerson/delete/{id}", 1))
+                .perform(
+                        post("/likeablePerson/delete/1")
+                                .with(csrf())
+                )
                 .andDo(print());
 
         // THEN

--- a/src/test/java/com/ll/gramgram/boundedContext/likeablePerson/controller/LikeablePersonControllerTests.java
+++ b/src/test/java/com/ll/gramgram/boundedContext/likeablePerson/controller/LikeablePersonControllerTests.java
@@ -178,34 +178,42 @@ public class LikeablePersonControllerTests {
     }
 
     @Test
-    @DisplayName("호감삭제(존재하지 않는 항목)")
+    @DisplayName("호감삭제(존재하지 않는 항목, 삭제 X)")
     @WithUserDetails("user3")
     void t007() throws Exception {
         // WHEN
         ResultActions resultActions = mvc
-                .perform(get("/likeablePerson/delete/{id}", 100))
+                .perform(
+                        delete("/likeablePerson/100")
+                                .with(csrf())
+                )
                 .andDo(print());
 
         // THEN
         resultActions
                 .andExpect(handler().handlerType(LikeablePersonController.class))
                 .andExpect(handler().methodName("delete"))
-                .andExpect(status().is2xxSuccessful());
+                .andExpect(status().is4xxClientError());
     }
 
     @Test
-    @DisplayName("호감삭제(권한 없음)")
-    @WithUserDetails("user1")
+    @DisplayName("호감삭제(권한 없음, 삭제 X)")
+    @WithUserDetails("user2")
     void t008() throws Exception {
         // WHEN
         ResultActions resultActions = mvc
-                .perform(get("/likeablePerson/delete/{id}", 1))
+                .perform(
+                        delete("/likeablePerson/1")
+                                .with(csrf())
+                )
                 .andDo(print());
 
         // THEN
         resultActions
                 .andExpect(handler().handlerType(LikeablePersonController.class))
                 .andExpect(handler().methodName("delete"))
-                .andExpect(status().is2xxSuccessful());
+                .andExpect(status().is4xxClientError());
+
+        assertThat(likeablePersonService.findById(1L).isPresent()).isEqualTo(true);
     }
 }

--- a/src/test/java/com/ll/gramgram/boundedContext/likeablePerson/controller/LikeablePersonControllerTests.java
+++ b/src/test/java/com/ll/gramgram/boundedContext/likeablePerson/controller/LikeablePersonControllerTests.java
@@ -172,7 +172,7 @@ public class LikeablePersonControllerTests {
                 .andExpect(status().is3xxRedirection())
                 .andExpect(redirectedUrlPattern("/likeablePerson/list**"));
 
-//        assertThat(likeablePersonService.findById(1L)).isEmpty();
+        assertThat(likeablePersonService.findById(1L).isPresent()).isEqualTo(false);
     }
 
     @Test


### PR DESCRIPTION
# 1Week_WooHyeJi.md

## Title: [1Week] 우혜지

### 미션 요구사항 분석 & 체크리스트

---
- [x] [필수] 호감상대 삭제
    - [x] 삭제 버튼을 눌렀을 시 해당 항목은 삭제되어야 한다.
    - [x] 삭제를 처리하기 전 해당 항목에 대한 소유권이 본인(로그인한 사람)에게 있는지 체크해야한다.
    - [x] 삭제 후 다시 호감목록 페이지로 돌아와야 한다. (`rq.redirectWithMsg` 사용)
- [x] [선택] 구글 로그인
    - [x] 구글 로그인으로 가입 및 로그인 처리가 가능하여야 한다. (스프링 OAuth2 클라이언트)
    - [x] 구글 로그인으로 가입한 회원의 providerTypeCode : GOOGLE

### 1주차 미션 요약

---

**[접근 방법]**
1. **호감상대 삭제**
    - 호감목록에서 삭제하려고 하는 항목은 LikeablePersonRepository 의 id 를 기준으로 찾야야한다.
        - LikeablePersonService 에서 `findById` 함수를 통해 해당 repository 에서 id를 가져온다.
    - LikeablePersonService 에서 `delete` 함수를 만든다.
        - 존재하지 않는 항목을 삭제하려고 했을 때 실패
        - 로그인한 사람에게 삭제 권한이 없는 경우 실패
    - LikeablePersonController 에서 해당 항목의 삭제버튼을 눌러 `"/delete/{id}"` 경로로 들어갔을 때 delete 구현
        - `"/delete/{id}"` 에서 id는 LikeablePersonRepository 에서 가져온 id
        - 호감상대 삭제가 실패한다면 `rq.historyBack` 을 통해 돌아간다.
    - 호감상대를 삭제한 후 `rq.redirectWithMsg` 를 통해 "/likeablePerson/list"로 돌아간다.
2. **구글 로그인**
    - 아직 구현하지 못함

**[특이사항]**
- 호감상대 삭제에 대한 테스트케이스는 실행되지만 GramgramApplication을 실행했을 때에는 list에서 삭제가 되지 않는 오류가 발생.
    
    -> LikeablePersonService.java 의 delete에 `@Transactional` 추가하니 삭제 가능 


**[Refactoring]**
1. **호감상대 삭제**
    - 호감취소 관련 변수명 정리
      - `RsData` -> `deleteRsData`
    - 호감상대 등록시 예외처리 케이스 메서드 새로 만들어서 분리
    - `@OneToMany` 사용하여 내가(or나를) 좋아하는 사람의 명단 양방향 관계 설정
      - 부작용이 생겨 오류 수정 (호감표시 페이지 작동 X)
    - 테스트케이스(t6, t7, t8) 수정
2. **카카오/구글 로그인**
    - 기존 카카오 clientId가 git에 노출됨
        -> application-secret.yml 새로 생성하여 정보 이동
    - 구글 프로젝트 생성 후 application.yml에 추가
        -> 카카오 로그인과 마찬가지로 clientId와 비밀번호는 application-secret.yml에서 관리
    - 협업 시 application-secret.yml은 git에 노출되지 않음
        -> 폼 제공을 위해 applicaion-secret.yml.default 문서 추가
3. **기타**
    - 영어로 commit message를 작성하다보니 미숙하여 자세하게 적지 못함
        -> 일부분 한글 작성으로 변경하기로 함